### PR TITLE
"WARN" must be capitalized

### DIFF
--- a/Embed.toml
+++ b/Embed.toml
@@ -9,7 +9,7 @@ restore_unwritten_bytes = false
 [default.general]
 chip = "stm32f401re"
 chip_descriptions = []
-log_level = "Warn"
+log_level = "WARN"
 
 [default.rtt]
 enabled = true


### PR DESCRIPTION
Default log level must be capitalized to compile.
https://github.com/probe-rs/cargo-embed/blob/master/src/config/default.toml