### PR TITLE
Upgrade `stm32f4xx-hal` to `^0.13`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ default = [
 cortex-m = "0.7"
 cortex-m-rt = "0.7"
 embedded-hal = "0.2"
-stm32f4xx-hal = { version = "0.12", features = ["rt", "stm32f401", "usb_fs"] }
+stm32f4xx-hal = { version = "0.13", features = ["rt", "stm32f401", "usb_fs"] }
 
 [dev-dependencies]
 defmt = "0.3.0"

--- a/src/button.rs
+++ b/src/button.rs
@@ -1,16 +1,16 @@
 use stm32f4xx_hal::{
-    gpio::{gpioc::PC13, Edge, ExtiPin, Input, PullUp},
+    gpio::{gpioc::PC13, Edge, ExtiPin, Input, PinMode},
     pac::EXTI,
     syscfg::SysCfg,
 };
 
 pub struct Button {
-    pin: PC13<Input<PullUp>>,
+    pin: PC13<Input>,
 }
 
 impl Button {
-    pub fn new<M>(pc13: PC13<M>) -> Self {
-        let pin = pc13.into_pull_up_input();
+    pub fn new(pc13: PC13<impl PinMode>) -> Self {
+        let pin = pc13.into_input().internal_pull_down(true);
         Self { pin }
     }
 

--- a/src/led.rs
+++ b/src/led.rs
@@ -1,4 +1,4 @@
-use stm32f4xx_hal::gpio::{gpioa::PA5, Output, PushPull};
+use stm32f4xx_hal::gpio::{gpioa::PA5, Output, PinMode, PushPull};
 
 /// Onboard led
 pub struct Led {
@@ -6,7 +6,7 @@ pub struct Led {
 }
 
 impl Led {
-    pub fn new<M>(pin: PA5<M>) -> Self {
+    pub fn new(pin: PA5<impl PinMode>) -> Self {
         let pa5 = pin.into_push_pull_output();
         Self { pa5 }
     }


### PR DESCRIPTION
`stm32f4xx-hal ^0.12` has a dependency issue where it doesn't pin the pre-release version number of `embedded-hal 1.0-alpha.*` and consequently fail to compile with a newer version of `embedded-hal`, which is automatically selected by Cargo for new projects. This issue was addressed in `stm32f4xx-hal 0.13.1`.